### PR TITLE
Bump node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ outputs:
       The labels on this PR. A dictionary containing `true` where a label
       exists
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'tag'  


### PR DESCRIPTION
[All Actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)