### PR TITLE
Bump top node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ outputs:
       The labels on this PR. A dictionary containing `true` where a label
       exists
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'tag'  


### PR DESCRIPTION
As node16 is deprecated and triggers warning.